### PR TITLE
docs: fix typo in for loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Basic usage:
   'author': 'Sarah',
   'body': "Yeah, it's working pretty well for me."}]
 >>> client.mutation("messages:send", dict(author="Me", body="Hello!"))
->>> for mesages client.subscribe("messages:list", {}):
+>>> for messages in client.subscribe("messages:list", {}):
 ...     print(len(messages))
 ...
 3


### PR DESCRIPTION
This simple PR fixes a typo in the example code present in README.md

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
